### PR TITLE
Simplify how strings are read from DocsDB and ExternalVocabulary

### DIFF
--- a/src/index/DocsDB.cpp
+++ b/src/index/DocsDB.cpp
@@ -30,6 +30,7 @@ string DocsDB::getTextExcerpt(Id cid) const {
   assert(to > from);
   size_t nofBytes = static_cast<size_t>(to - from);
   string line(nofBytes, '\0');
+  // TODO in C++17 we'll get non-const pointer std::string::data() use it the
   _dbFile.read(&line.front(), nofBytes, from);
   return line;
 }

--- a/src/index/DocsDB.cpp
+++ b/src/index/DocsDB.cpp
@@ -21,19 +21,15 @@ void DocsDB::init(const string& fileName) {
 string DocsDB::getTextExcerpt(Id cid) const {
   off_t ft[2];
   off_t& from = ft[0];
-  from = 0;
   off_t& to = ft[1];
   off_t at = _startOfOffsets + cid * sizeof(off_t);
-  at += _dbFile.read(ft, 2 * sizeof(off_t), at);
+  at += _dbFile.read(ft, sizeof(ft), at);
   while(to == from) {
     at += _dbFile.read(&to, sizeof(off_t), at);
   }
   assert(to > from);
   size_t nofBytes = static_cast<size_t>(to - from);
-  char* buf = new char[nofBytes + 1];
-  _dbFile.read(buf, nofBytes, from);
-  buf[nofBytes] = 0;
-  string line = buf;
-  delete[] buf;
+  string line(nofBytes, '\0');
+  _dbFile.read(&line.front(), nofBytes, from);
   return line;
 }

--- a/src/index/ExternalVocabulary.cpp
+++ b/src/index/ExternalVocabulary.cpp
@@ -10,14 +10,12 @@ string ExternalVocabulary::operator[](Id id) const {
   off_t& from = ft[0];
   off_t& to = ft[1];
   off_t at = _startOfOffsets + id * sizeof(off_t);
-  at += _file.read(ft, 2 * sizeof(off_t), at);
+  at += _file.read(ft, sizeof(ft), at);
   assert(to > from);
   size_t nofBytes = static_cast<size_t>(to - from);
-  char* buf = new char[nofBytes + 1];
-  _file.read(buf, nofBytes, from);
-  buf[nofBytes] = 0;
-  string word = buf;
-  delete[] buf;
+  string word(nofBytes,'\0');
+  // TODO in C++17 we'll get non-const pointer std::string::data() use it then
+  _file.read(&word.front(), nofBytes, from);
   return word;
 }
 

--- a/src/index/ExternalVocabulary.h
+++ b/src/index/ExternalVocabulary.h
@@ -26,7 +26,7 @@ public:
 
   void initFromFile(const string& file);
 
-  //! Get the word with the given id (as lvalue)
+  //! Get the word with the given id (as rvalue)
   string operator[](Id id) const;
 
   //! Get the number of words in the vocabulary.


### PR DESCRIPTION
Currently the words in the external vocabulary and the docs in DocsDB are turned into std::strings by creating a temporary heap allocated char array and constructing a std::string from that.

Instead we can use the contiguous memory guarantee introduced in C++11 to read directly into a string of the right size. When C++17 comes along we can even change this to use non-const .data() to make it cleaner.

While we are add it fix a comment.