### PR TITLE
Fixes to getLower/UppercaseUtf8()

### DIFF
--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -190,11 +190,11 @@ string getLowercaseUtf8(const string& orig) {
   std::mbstate_t state = std::mbstate_t();
   char buf[MB_CUR_MAX + 1];
   for (size_t i = 0; i < orig.size(); ++i) {
-    if (static_cast<int>(orig[i]) >= 0) {
+    if ((orig[i] & (1<<7)) == 0) {
       retVal += tolower(orig[i]);
     } else {
       wchar_t wChar;
-      size_t len = mbrtowc(&wChar, &orig[i], MB_CUR_MAX, &state);
+      size_t len = mbrtowc(&wChar, &orig[i], orig.size()-i, &state);
       // If this assertion fails, there is an invalid multi-byte character.
       // However, this usually means that the locale is not utf8.
       // Note that the default locale is always C. Main classes need to set them
@@ -218,11 +218,11 @@ string getUppercaseUtf8(const string& orig) {
   std::mbstate_t state = std::mbstate_t();
   char buf[MB_CUR_MAX + 1];
   for (size_t i = 0; i < orig.size(); ++i) {
-    if (static_cast<int>(orig[i]) >= 0) {
+    if ((orig[i] & (1 <<7)) == 0) {
       retVal += toupper(orig[i]);
     } else {
       wchar_t wChar;
-      size_t len = mbrtowc(&wChar, &orig[i], MB_CUR_MAX, &state);
+      size_t len = mbrtowc(&wChar, &orig[i], orig.size()-i, &state);
       // If this assertion fails, there is an invalid multi-byte character.
       // However, this usually means that the locale is not utf8.
       // Note that the default locale is always C. Main classes need to set them


### PR DESCRIPTION
On e.g. ARM and POWER char is unsigned (yeah because having it signed
wasn't stupid enough they had to make it implementation defined). Thus
the > 0 check for ASCII characters doesn't work, instead check if
the most significant bit is set.

I have confirmed both the old and new behavior on my Raspberry Pi.

Also I think the size argument should take the end of the string into
account so as to never read past it even for invalid characters.

On another note I wonder if it might be faster to first take a pass over the string
to determine the final length and then allocate in one go. Then again this would
only matter if this function shows up in profiling.