### PR TITLE
Add list of selected variables to JSON output

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -301,6 +301,8 @@ string Server::composeResponseJson(const ParsedQuery& query,
                                    const QueryExecutionTree& qet,
                                    size_t maxSend) const {
 
+  // TODO(schnelle) we really should use a json library
+  // such as https://github.com/nlohmann/json
   const ResultTable& rt = qet.getResult();
   _requestProcessingTimer.stop();
   off_t compResultUsecs = _requestProcessingTimer.usecs();
@@ -314,6 +316,14 @@ string Server::composeResponseJson(const ParsedQuery& query,
      << "\",\n"
      << "\"status\": \"OK\",\n"
      << "\"resultsize\": \"" << resultSize << "\",\n";
+
+  os << "\"selected\": ";
+  if (query._selectedVariables.size()) {
+    os << "[\"" <<
+      ad_utility::join(query._selectedVariables, "\", \"") << "\"],\n";
+  } else {
+    os << "[],\n";
+  }
 
   os << "\"res\": ";
   size_t limit = MAX_NOF_ROWS_IN_RESULT;


### PR DESCRIPTION
This allows matching the result columns to variables without access to the
original query or parsing the query in the response. This also makes our JSON
output a bit more like the virtuoso JSON interface allowing better code sharing
in Aqqu where the query is only accessible as a string when building the result
table. While we are here add a TODO for using a JSON library.

Tested for interference with existing code on the Scientists KB