### PR TITLE
Fix #25

### DIFF
--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -857,7 +857,7 @@ void Index::scanNonFunctionalRelation(const pair<off_t, size_t>& blockOff,
       } else {
         LOG(TRACE) << "Special case: extra scan of follow block!\n";
         pair<Id, off_t> follower;
-        _psoFile.read(&follower, sizeof(follower), followBlock.first);
+        indexFile.read(&follower, sizeof(follower), followBlock.first);
         nofBytes = static_cast<size_t>(follower.second - it->second);
       }
     }


### PR DESCRIPTION
Testing out my hypothesis that scanNonFunctionalRelation's special case for scanning the follow block should not read that from the psoFile it seems to fix the crash and return a correct result. Sadly I'm not sure how to trigger this in a small test query so I don't have a nice regression test.

My original argument was:

> It seems to me that _psoFile is a WidthTwoList so pairs of Ids but we're trying to read a pair<Id, off_t> which is what indexFile consists of? Also the comments say we want to read a follow block but blocks are read from the indexFile
