### PR TITLE
Allowed blank nodes in nt file parsing

### DIFF
--- a/src/parser/NTriplesParser.cpp
+++ b/src/parser/NTriplesParser.cpp
@@ -29,7 +29,8 @@ bool NTriplesParser::getLine(array<string, 3>& res) {
     size_t j = i + 1;
     while (j < line.size() && line[j] != '\t' && line[j] != ' ') { ++j; }
     assert(j < line.size());
-    if (!(line[i] == '<' && line[j - 1] == '>')) {
+    if (!((line[i] == '<' && line[j - 1] == '>')
+          || (i + 1 < line.size() && line[i] == '_' && line[i+  1] == ':'))) {
       AD_THROW(ad_semsearch::Exception::BAD_INPUT, "Illegal URI in : " + line);
     }
     res[0] = line.substr(i, j - i);
@@ -53,6 +54,10 @@ bool NTriplesParser::getLine(array<string, 3>& res) {
                  "Illegal URI in : " + line);
       }
       ++j;
+    } else if(line[i] == '_' && i + 1 < line.size() && line[i + 1] == ':') {
+      // Blank node
+      j = i + 1;
+      while (j < line.size() && line[j] != '\t' && line[j] != ' ') { ++j; }
     } else {
       // Literal
       j = line.find('\"', i + 1);

--- a/src/parser/NTriplesParser.cpp
+++ b/src/parser/NTriplesParser.cpp
@@ -30,7 +30,7 @@ bool NTriplesParser::getLine(array<string, 3>& res) {
     while (j < line.size() && line[j] != '\t' && line[j] != ' ') { ++j; }
     assert(j < line.size());
     if (!((line[i] == '<' && line[j - 1] == '>')
-          || (i + 1 < line.size() && line[i] == '_' && line[i+  1] == ':'))) {
+          || (i + 1 < line.size() && line[i] == '_' && line[i + 1] == ':'))) {
       AD_THROW(ad_semsearch::Exception::BAD_INPUT, "Illegal URI in : " + line);
     }
     res[0] = line.substr(i, j - i);

--- a/test/NTriplesParserTest.cpp
+++ b/test/NTriplesParserTest.cpp
@@ -56,6 +56,30 @@ TEST(NTriplesParserTest, getLineTest) {
       ASSERT_FALSE(p.getLine(a));
       remove("_testtmp.nt");
     }
+    // blank nodes
+    {
+      std::fstream f("_testtmp.nt", std::ios_base::out);
+      f << "<node1> <rel1> _:b.lank_node_id1 .\n"
+           "_:b.lank_node_id1\t<rel2> \"goat cheese.\" .\n"
+           "_:bla--nk_no.de_id.4 <relasd> _:b.lank_node_id1 .\n";
+      f.close();
+      NTriplesParser p("_testtmp.nt");
+      array<string, 3> a;
+      ASSERT_TRUE(p.getLine(a));
+      ASSERT_EQ("<node1>", a[0]);
+      ASSERT_EQ("<rel1>", a[1]);
+      ASSERT_EQ("_:b.lank_node_id1", a[2]);
+      ASSERT_TRUE(p.getLine(a));
+      ASSERT_EQ("_:b.lank_node_id1", a[0]);
+      ASSERT_EQ("<rel2>", a[1]);
+      ASSERT_EQ("\"goat cheese.\"", a[2]);
+      ASSERT_TRUE(p.getLine(a));
+      ASSERT_EQ("_:bla--nk_no.de_id.4", a[0]);
+      ASSERT_EQ("<relasd>", a[1]);
+      ASSERT_EQ("_:b.lank_node_id1", a[2]);
+      ASSERT_FALSE(p.getLine(a));
+      remove("_testtmp.nt");
+    }
   } catch (const ad_semsearch::Exception& e) {
     FAIL() << e.getFullErrorMessage();
   }


### PR DESCRIPTION
Changed the NTParser to accept blank nodes as subjects and objects. Fixes #27 when parsing .nt files.