### PR TITLE
Changed emph_off to [22m instead of [21m.

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -21,7 +21,7 @@ using std::flush;
 using std::cerr;
 
 #define EMPH_ON  "\033[1m"
-#define EMPH_OFF "\033[21m"
+#define EMPH_OFF "\033[22m"
 
 // Available options.
 struct option options[] = {

--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -21,7 +21,7 @@ using std::flush;
 using std::cerr;
 
 #define EMPH_ON  "\033[1m"
-#define EMPH_OFF "\033[21m"
+#define EMPH_OFF "\033[22m"
 
 // Available options.
 struct option options[] = {

--- a/src/WriteIndexListsMain.cpp
+++ b/src/WriteIndexListsMain.cpp
@@ -24,7 +24,7 @@ using std::flush;
 using std::cerr;
 
 #define EMPH_ON  "\033[1m"
-#define EMPH_OFF "\033[21m"
+#define EMPH_OFF "\033[22m"
 
 // Available options.
 struct option options[] = {

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -23,7 +23,7 @@ using std::flush;
 using std::cerr;
 
 #define EMPH_ON  "\033[1m"
-#define EMPH_OFF "\033[21m"
+#define EMPH_OFF "\033[22m"
 
 // Available options.
 struct option options[] = {


### PR DESCRIPTION
According to wikipedias page on ansi escape codes ([link](https://en.wikipedia.org/wiki/ANSI_escape_code)) the EMPH_OFF code should be \0x1b[22m instead of \0x1b[21m which is interpreted by some terminals as turning underlining on.