### PR TITLE
Fix parseexception returning freed memory

### DIFF
--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -144,7 +144,7 @@ int main(int argc, char** argv) {
       }
     }
   } catch (const std::exception& e) {
-    cout << string("Caught exceptions: ") + e.what();
+    cout << string("Caught exceptions: ") + e.what() << std::endl;
     return 1;
   } catch (ad_semsearch::Exception& e) {
     cout << e.getFullErrorMessage() << std::endl;

--- a/src/parser/ParseException.h
+++ b/src/parser/ParseException.h
@@ -10,11 +10,12 @@ class ParseException : public std::exception {
 
 public:
 
-  ParseException(string _cause) : std::exception(), _cause(_cause) {
+  ParseException(string _cause) : std::exception(),
+    _cause(string("ParseException, cause: ") + _cause) {
   }
 
   virtual const char* what() const throw() {
-    return (string("ParseException, cause: ") +  _cause).c_str();
+    return _cause.c_str();
   }
 
 private:


### PR DESCRIPTION
In the ParseExceptions what() method a local string was assembled, and then a pointer to its data is returned using c_str(). As the string is deleted when the method returns, and before the string is written to stdout the strings data could be modified before printing, leading to garbled exception printing. 