### PR TITLE
Add support for the short form of xsd values

### DIFF
--- a/src/util/Conversions.h
+++ b/src/util/Conversions.h
@@ -96,7 +96,10 @@ string convertValueLiteralToIndexWord(const string& orig) {
                        orig.size() - (posOfHashTag + 2));
   } else {
     size_t posOfDoubleDot = orig.rfind(':');
-    assert(posOfDoubleDot != string::npos);
+    if (posOfDoubleDot == string::npos) {
+      AD_THROW(ad_semsearch::Exception::BAD_INPUT,
+               "No ':' in non-URL ValueLiteral " + orig);
+    }
 
     // +1 for double dot
     type = orig.substr(posOfDoubleDot + 1,
@@ -513,7 +516,9 @@ inline string removeLeadingZeros(const string& orig) {
 
 // _____________________________________________________________________________
 bool isXsdValue(const string val) {
-  return val.size() > 0 && val[0] == '\"' && val.find("\"^^") != string::npos;
+  // starting the search for "^^ at position 1 makes sure it's not in the
+  // quotes as we already checked that the first char is the first quote
+  return val.size() > 0 && val[0] == '\"' && val.find("\"^^", 1) != string::npos;
 }
 }
 

--- a/test/ConversionsTest.cpp
+++ b/test/ConversionsTest.cpp
@@ -128,10 +128,33 @@ TEST(ConversionsTest, convertDateToIndexWord) {
 TEST(ConversionsTest, endToEndDate) {
   string in = "\"1990-01-01T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>";
   string in2 = "\"1990-01-01\"^^<http://www.w3.org/2001/XMLSchema#date>";
+  string in3 = "\"1990-01-01\"^^xsd:date";
+  string in4 = "\"1990-01-01T00:00:00\"^^xsd:dateTime";
   string indexW = ":v:date:0000000000000001990-01-01T00:00:00";
   ASSERT_EQ(indexW, convertValueLiteralToIndexWord(in));
   ASSERT_EQ(indexW, convertValueLiteralToIndexWord(in2));
+  ASSERT_EQ(indexW, convertValueLiteralToIndexWord(in3));
+  ASSERT_EQ(indexW, convertValueLiteralToIndexWord(in4));
   ASSERT_EQ(in, convertIndexWordToValueLiteral(indexW));
+}
+
+TEST(ConversionsTest, shortFormEquivalence) {
+  string in = "\"1230.7\"^^<http://www.w3.org/2001/XMLSchema#float>";
+  string in_short = "\"1230.7\"^^xsd:float";
+  string nin = "\"-1230.7\"^^<http://www.w3.org/2001/XMLSchema#float>";
+  string nin_short = "\"-1230.7\"^^xsd:float";
+  string in2 = "\"1000\"^^<http://www.w3.org/2001/XMLSchema#int>";
+  string in2_short = "\"1000\"^^xsd:int";
+  string nin2 = "\"-1000\"^^<http://www.w3.org/2001/XMLSchema#int>";
+  string nin2_short = "\"-1000\"^^xsd:int";
+  ASSERT_EQ(convertValueLiteralToIndexWord(in),
+            convertValueLiteralToIndexWord(in_short));
+  ASSERT_EQ(convertValueLiteralToIndexWord(nin),
+            convertValueLiteralToIndexWord(nin_short));
+  ASSERT_EQ(convertValueLiteralToIndexWord(in2),
+            convertValueLiteralToIndexWord(in2_short));
+  ASSERT_EQ(convertValueLiteralToIndexWord(nin2),
+            convertValueLiteralToIndexWord(nin2_short));
 }
 
 TEST(ConversionsTest, endToEndNumbers) {


### PR DESCRIPTION
Instead of giving the full URL xsd values may use a short form "123"^^xsd:integer, add support for this. As before we don't really care for the URL but support some base types.

Tests are included