### PR TITLE
Added splitting at multiple whitespace characters

### DIFF
--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -63,7 +63,7 @@ void SparqlParser::parsePrologue(string str, ParsedQuery& query) {
 
 // _____________________________________________________________________________
 void SparqlParser::addPrefix(const string& str, ParsedQuery& query) {
-  auto parts = ad_utility::splitWs(ad_utility::strip(str, ' '));
+  auto parts = ad_utility::splitWs(str);
   if (parts.size() != 3) {
     throw ParseException(string("Invalid PREFIX statement: ") + str);
   }

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -63,7 +63,7 @@ void SparqlParser::parsePrologue(string str, ParsedQuery& query) {
 
 // _____________________________________________________________________________
 void SparqlParser::addPrefix(const string& str, ParsedQuery& query) {
-  auto parts = ad_utility::split(ad_utility::strip(str, ' '), ' ');
+  auto parts = ad_utility::splitWs(ad_utility::strip(str, ' '));
   if (parts.size() != 3) {
     throw ParseException(string("Invalid PREFIX statement: ") + str);
   }
@@ -73,12 +73,12 @@ void SparqlParser::addPrefix(const string& str, ParsedQuery& query) {
   }
   SparqlPrefix p{ad_utility::strip(parts[1], " :\t\n"), uri};
   query._prefixes.emplace_back(p);
-};
+}
 
 // _____________________________________________________________________________
 void SparqlParser::parseSelect(const string& str, ParsedQuery& query) {
   assert(ad_utility::startsWith(str, "SELECT"));
-  auto vars = ad_utility::split(str, ' ');
+  auto vars = ad_utility::splitWs(str);
   size_t i = 1;
   if (vars.size() > i && vars[i] == "DISTINCT") {
     ++i;

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -110,7 +110,7 @@ inline string rstrip(const string& text, const char *s);
 inline vector<string> split(const string& orig, const char sep);
 
 //! Splits a string at any maximum length sequence of whitespace
-inline vector<string> splitWs(const string &orig);
+inline vector<string> splitWs(const string& orig);
 
 //! Splits a string a any character inside the seps string.
 inline vector<string> splitAny(const string& orig, const char *seps);
@@ -386,18 +386,19 @@ vector<string> split(const string& orig, const char sep) {
 }
 
 // _____________________________________________________________________________
-vector<string> splitWs(const string &orig) {
+vector<string> splitWs(const string& orig) {
   vector<string> result;
   if (orig.size() > 0) {
     size_t start = 0;
     size_t pos = 0;
     while (pos < orig.size()) {
-      if (orig[pos] >= 0 && ::isspace(orig[pos])) {
+      if (::isspace(static_cast<unsigned char>(orig[pos]))) {
         if (start != pos) {
           result.emplace_back(orig.substr(start, pos - start));
         }
         // skip any whitespace
-        while (pos < orig.size() && orig[pos] >= 0 && ::isspace(orig[pos])) {
+        while (pos < orig.size()
+               && ::isspace(static_cast<unsigned char>(orig[pos]))) {
           pos++;
         }
         start = pos;
@@ -405,7 +406,8 @@ vector<string> splitWs(const string &orig) {
       pos++;
     }
     // avoid adding whitespace at the back of the string
-    if (!(orig[orig.size() - 1] >= 0 && ::isspace(orig[orig.size() - 1]))) {
+    // if (!::isspace(static_cast<unsigned char>(orig[orig.size() - 1]))) {
+    if (start != orig.size()) {
       result.emplace_back(orig.substr(start));
     }
   }

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <iostream>
+#include <cctype>
 #include <clocale>
 #include <cstring>
 #include <cwchar>
@@ -107,6 +108,9 @@ inline string rstrip(const string& text, const char *s);
 
 //! Splits a string at the separator, kinda like python.
 inline vector<string> split(const string& orig, const char sep);
+
+//! Splits a string at any maximum length sequence of whitespace
+inline vector<string> splitWs(const string &orig);
 
 //! Splits a string a any character inside the seps string.
 inline vector<string> splitAny(const string& orig, const char *seps);
@@ -377,6 +381,33 @@ vector<string> split(const string& orig, const char sep) {
       sepIndex = orig.find(sep, from);
     }
     result.emplace_back(orig.substr(from));
+  }
+  return result;
+}
+
+// _____________________________________________________________________________
+vector<string> splitWs(const string &orig) {
+  vector<string> result;
+  if (orig.size() > 0) {
+    size_t start = 0;
+    size_t pos = 0;
+    while (pos < orig.size()) {
+      if (isspace(orig[pos])) {
+        if (start != pos) {
+          result.emplace_back(orig.substr(start, pos - start));
+        }
+        // skip any whitespace
+        while (pos < orig.size() && isspace(orig[pos])) {
+          pos++;
+        }
+        start = pos;
+      }
+      pos++;
+    }
+    // avoid adding whitespace at the back of the string
+    if (!isspace(orig[orig.size() - 1])) {
+      result.emplace_back(orig.substr(start, pos - start));
+    }
   }
   return result;
 }

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -7,8 +7,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <ctype.h>
 #include <iostream>
-#include <cctype>
 #include <clocale>
 #include <cstring>
 #include <cwchar>
@@ -392,12 +392,12 @@ vector<string> splitWs(const string &orig) {
     size_t start = 0;
     size_t pos = 0;
     while (pos < orig.size()) {
-      if (isspace(orig[pos])) {
+      if (orig[pos] >= 0 && ::isspace(orig[pos])) {
         if (start != pos) {
           result.emplace_back(orig.substr(start, pos - start));
         }
         // skip any whitespace
-        while (pos < orig.size() && isspace(orig[pos])) {
+        while (pos < orig.size() && orig[pos] >= 0 && ::isspace(orig[pos])) {
           pos++;
         }
         start = pos;
@@ -405,8 +405,8 @@ vector<string> splitWs(const string &orig) {
       pos++;
     }
     // avoid adding whitespace at the back of the string
-    if (!isspace(orig[orig.size() - 1])) {
-      result.emplace_back(orig.substr(start, pos - start));
+    if (!(orig[orig.size() - 1] >= 0 && ::isspace(orig[orig.size() - 1]))) {
+      result.emplace_back(orig.substr(start));
     }
   }
   return result;

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -211,6 +211,45 @@ TEST(StringUtilsTest, strip) {
   ASSERT_EQ(u8"äö", strip(u8"xxaxaxaxaäöaaaxxx", "xa"));
   ASSERT_EQ("xxaxaxaxa♥", rstrip("xxaxaxaxa♥aaaxxx", "xa"));
 }
+
+
+TEST(StringUtilsTest, splitWs) {
+  string s1 = "  this\nis\t  \nit  ";
+  string s2 = "\n   \t  \n \t";
+  string s3 = "thisisit";
+  string s4 = "this is\nit";
+  string s5 = "a";
+  auto v1 = splitWs(s1);
+  ASSERT_EQ(size_t(3), v1.size());
+  ASSERT_EQ("this", v1[0]);
+  ASSERT_EQ("is", v1[1]);
+  ASSERT_EQ("it", v1[2]);
+
+  auto v2 = splitWs(s2);
+  ASSERT_EQ(size_t(0), v2.size());
+
+
+  auto v3 = splitWs(s3);
+  ASSERT_EQ(size_t(1), v3.size());
+  ASSERT_EQ("thisisit", v3[0]);
+
+  auto v4 = splitWs(s4);
+  ASSERT_EQ(size_t(3), v4.size());
+  ASSERT_EQ("this", v4[0]);
+  ASSERT_EQ("is", v4[1]);
+  ASSERT_EQ("it", v4[2]);
+
+  auto v5 = splitWs(s5);
+  ASSERT_EQ(size_t(1), v5.size());
+  ASSERT_EQ("a", v5[0]);
+
+  // and with unicode
+  string s6 = u8"Spaß \t ❤ \n漢字  ";
+  auto v6 = splitWs(s6);
+  ASSERT_EQ(u8"Spaß", v6[0]);
+  ASSERT_EQ(u8"❤", v6[1]);
+  ASSERT_EQ(u8"漢字", v6[2]);
+}
 }  // namespace
 
 

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -214,6 +214,7 @@ TEST(StringUtilsTest, strip) {
 
 
 TEST(StringUtilsTest, splitWs) {
+  setlocale(LC_CTYPE, "en_US.utf8");
   string s1 = "  this\nis\t  \nit  ";
   string s2 = "\n   \t  \n \t";
   string s3 = "thisisit";
@@ -227,7 +228,6 @@ TEST(StringUtilsTest, splitWs) {
 
   auto v2 = splitWs(s2);
   ASSERT_EQ(size_t(0), v2.size());
-
 
   auto v3 = splitWs(s3);
   ASSERT_EQ(size_t(1), v3.size());
@@ -249,6 +249,14 @@ TEST(StringUtilsTest, splitWs) {
   ASSERT_EQ(u8"Spaß", v6[0]);
   ASSERT_EQ(u8"❤", v6[1]);
   ASSERT_EQ(u8"漢字", v6[2]);
+
+  // unicode code point 224 has a second byte (160), that equals the space
+  // character if the first bit is ignored
+  // (which may happen when casting char to int).
+  string s7 = u8"Test\u00e0test";
+  auto v7 = splitWs(s7);
+  ASSERT_EQ(1u, v7.size());
+  ASSERT_EQ(s7, v7[0]);
 }
 }  // namespace
 


### PR DESCRIPTION
I added a splitWs function to the StringUtils and used that during the SparqlParsing to allow for multiple whitespace characters between variable names in the select part and within prefix declarations.
This allows for direct usage of the queries of e.g. the sp2b benchmark, and is also used within the examples in the W3C recommendation for sparql.